### PR TITLE
feat(core): scaffold core package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 .DS_Store
 *.log
 coverage/
+
+!packages/core/dist/
+!packages/core/dist/**

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @slatecss/core
+
+## 0.0.0
+
+- Initial release.

--- a/packages/core/dist/exports.json
+++ b/packages/core/dist/exports.json
@@ -1,0 +1,1 @@
+{ "brand": {"echoLight":"#b8d2ed","slateMuted":"#566590","indigoGray":"#42436c","tealDeep":"#1c4566","slateDark":"#323460","navyMidnight":"#03284f"} }

--- a/packages/core/dist/index.css
+++ b/packages/core/dist/index.css
@@ -1,0 +1,11 @@
+:root{--brand-echo-light:#b8d2ed;--brand-slate-muted:#566590;--brand-indigogray:#42436c;--brand-teal-deep:#1c4566;--brand-slate-dark:#323460;--brand-navy-midnight:#03284f;--color-bg:#f7f8fa;--color-surface:#ffffff;--color-border:#e5e9f2;--color-text:#0f1220;--font-sans:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:16px}
+@media (prefers-color-scheme: dark){:root{--color-bg:#0e121b;--color-surface:#121826;--color-border:#1f293b;--color-text:#e8edf7}}
+[data-theme="dark"]{--color-bg:#0e121b;--color-surface:#121826;--color-border:#1f293b;--color-text:#e8edf7}
+*,*::before,*::after{box-sizing:border-box}
+html{color-scheme:light dark}
+body{margin:0;background:var(--color-bg);color:var(--color-text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+h1,h2,h3{font-weight:700}
+p{line-height:1.6}
+h1{font-family:var(--font-sans);font-size:clamp(2.25rem,4vw,3rem)}
+h2{font-family:var(--font-sans);font-size:clamp(1.75rem,3vw,2.25rem)}
+h3{font-family:var(--font-sans);font-size:clamp(1.5rem,2.5vw,1.875rem)}

--- a/packages/core/dist/palette.css
+++ b/packages/core/dist/palette.css
@@ -1,0 +1,1 @@
+:root{--brand-echo-light:#b8d2ed;--brand-slate-muted:#566590;--brand-indigogray:#42436c;--brand-teal-deep:#1c4566;--brand-slate-dark:#323460;--brand-navy-midnight:#03284f;--color-bg:#f7f8fa;--color-surface:#ffffff;--color-border:#e5e9f2;--color-text:#0f1220}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,1 +1,13 @@
-{ "name":"@slatecss/core", "version":"0.0.0", "type":"module" }
+{
+  "name": "@slatecss/core",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "style": "./dist/index.css",
+  "files": [
+    "dist",
+    "src"
+  ]
+}

--- a/packages/core/src/base/_base.scss
+++ b/packages/core/src/base/_base.scss
@@ -1,0 +1,1 @@
+h1,h2,h3{font-weight:700}p{line-height:1.6}

--- a/packages/core/src/base/_reset.scss
+++ b/packages/core/src/base/_reset.scss
@@ -1,0 +1,1 @@
+*,*::before,*::after{box-sizing:border-box}html{color-scheme:light dark}body{margin:0;background:var(--color-bg);color:var(--color-text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}

--- a/packages/core/src/index.scss
+++ b/packages/core/src/index.scss
@@ -1,0 +1,2 @@
+@forward "typography/scale";
+@forward "tokens/palette";@forward "tokens/shade";@forward "base/reset";@forward "base/base";

--- a/packages/core/src/tokens/_exports.json
+++ b/packages/core/src/tokens/_exports.json
@@ -1,0 +1,1 @@
+{ "brand": {"echoLight":"#b8d2ed","slateMuted":"#566590","indigoGray":"#42436c","tealDeep":"#1c4566","slateDark":"#323460","navyMidnight":"#03284f"} }

--- a/packages/core/src/tokens/_palette.scss
+++ b/packages/core/src/tokens/_palette.scss
@@ -1,0 +1,2 @@
+:root{--brand-echo-light:#b8d2ed;--brand-slate-muted:#566590;--brand-indigogray:#42436c;--brand-teal-deep:#1c4566;--brand-slate-dark:#323460;--brand-navy-midnight:#03284f;--color-bg:#f7f8fa;--color-surface:#ffffff;--color-border:#e5e9f2;--color-text:#0f1220}
+@mixin slate-brand(){ /* map placeholders for SCSS usage */ }

--- a/packages/core/src/tokens/_shade.scss
+++ b/packages/core/src/tokens/_shade.scss
@@ -1,0 +1,2 @@
+@media (prefers-color-scheme: dark){:root{--color-bg:#0e121b;--color-surface:#121826;--color-border:#1f293b;--color-text:#e8edf7}}
+[data-theme="dark"]{--color-bg:#0e121b;--color-surface:#121826;--color-border:#1f293b;--color-text:#e8edf7}

--- a/packages/core/src/tokens/_zindex.scss
+++ b/packages/core/src/tokens/_zindex.scss
@@ -1,0 +1,2 @@
+$z: (dropdown: 1000, modal: 1100, toast: 1200) !default;
+@mixin z($k){ z-index: map.get($z, $k); }

--- a/packages/core/src/typography/_scale.scss
+++ b/packages/core/src/typography/_scale.scss
@@ -1,0 +1,4 @@
+:root{--font-sans:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:16px}
+h1{font-family:var(--font-sans);font-size:clamp(2.25rem,4vw,3rem)}
+h2{font-family:var(--font-sans);font-size:clamp(1.75rem,3vw,2.25rem)}
+h3{font-family:var(--font-sans);font-size:clamp(1.5rem,2.5vw,1.875rem)}

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -1,0 +1,1 @@
+export default { build: { lib: { entry: "packages/core/src/index.scss", formats: ["es"] }}}


### PR DESCRIPTION
## Summary
- scaffold @slatecss/core package with build config
- add palette, shade, z-index, and typography tokens
- include base reset and dist assets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b76ca0b8188329ae14cbc648dffb84