### PR TITLE
feat(grid): add matrix grid package

### DIFF
--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -1,0 +1,14 @@
+# @slatecss/grid
+
+```scss
+@use "@slatecss/grid" as grid;
+
+.container {
+  @include grid.matrix(3);
+  @include grid.gap("2");
+}
+
+.item {
+  @include grid.col-span(2);
+}
+```

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -1,1 +1,13 @@
-{ "name":"@slatecss/grid", "version":"0.0.0", "type":"module" }
+{
+  "name": "@slatecss/grid",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "style": "./dist/index.css",
+  "files": [
+    "dist",
+    "src"
+  ]
+}

--- a/packages/grid/src/_gaps.scss
+++ b/packages/grid/src/_gaps.scss
@@ -1,0 +1,2 @@
+$gaps: ("0":0, "1":.25rem, "2":.5rem, "3":.75rem, "4":1rem) !default;
+@mixin gap($key){ gap: map-get($gaps, $key); }

--- a/packages/grid/src/_matrix.scss
+++ b/packages/grid/src/_matrix.scss
@@ -1,0 +1,9 @@
+@use "sass:meta";
+@mixin matrix($cols, $gap: 1rem, $flow: row, $inline: false){
+  display: if($inline, inline-grid, grid);
+  grid-template-columns: if(meta.type-of($cols) == number, repeat($cols, minmax(0,1fr)), $cols);
+  gap: $gap;
+  grid-auto-flow: $flow;
+}
+@mixin col-span($n){ grid-column: span $n; }
+@mixin row-span($n){ grid-row: span $n; }

--- a/packages/grid/src/_sense.scss
+++ b/packages/grid/src/_sense.scss
@@ -1,0 +1,1 @@
+@mixin at-container($query){ @container #{$query} { @content; } }

--- a/packages/grid/src/index.scss
+++ b/packages/grid/src/index.scss
@@ -1,0 +1,4 @@
+@forward "matrix";
+@forward "gaps";
+@forward "sense";
+/* Matrix entry */

--- a/packages/grid/src/utilities.scss
+++ b/packages/grid/src/utilities.scss
@@ -1,0 +1,2 @@
+.matrix--col { grid-auto-flow: column; }
+@for $i from 1 through 12 { .u-col-span-#{$i} { grid-column: span #{$i}; } }

--- a/packages/grid/vite.config.ts
+++ b/packages/grid/vite.config.ts
@@ -1,0 +1,1 @@
+export default { build:{ lib:{ entry:"packages/grid/src/index.scss", formats:["es"] }}}


### PR DESCRIPTION
## Summary
- scaffold `@slatecss/grid` package with build plumbing
- add matrix, gap, and container-query mixins
- expose optional utilities and prepare package for publish

## Testing
- `pnpm -w install || npm install --package-lock-only`
- `pnpm -F @slatecss/grid build`
- `pnpm -F @slatecss/grid pack`


------
https://chatgpt.com/codex/tasks/task_e_68b77912a5bc8329a4d3a21efeac34d2