### PR TITLE
feat: scaffold utilities package and helpers

### DIFF
--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -1,1 +1,13 @@
-{ "name":"@slatecss/utilities", "version":"0.0.0", "type":"module" }
+{
+  "name": "@slatecss/utilities",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "style": "./dist/index.css",
+  "files": [
+    "dist",
+    "src"
+  ]
+}

--- a/packages/utilities/src/balance.scss
+++ b/packages/utilities/src/balance.scss
@@ -1,0 +1,2 @@
+/* Equalize pattern (CSS-first); JS fallback later if needed */
+.balance > *{ block-size: 100%; }

--- a/packages/utilities/src/config.scss
+++ b/packages/utilities/src/config.scss
@@ -1,0 +1,4 @@
+$emit-spacing: true !default;
+$emit-display: true !default;
+$emit-text: true !default;
+$emit-grid-span: true !default;

--- a/packages/utilities/src/index.scss
+++ b/packages/utilities/src/index.scss
@@ -1,0 +1,7 @@
+@forward "scope";@forward "steps";@forward "balance";
+@use "./config";
+@use "./quick" as q;
+@if config.$emit-spacing { @include q.spacing(); }
+@if config.$emit-display { @include q.display(); }
+@if config.$emit-text { @include q.text(); }
+@if config.$emit-grid-span { @include q.gridSpan(12); }

--- a/packages/utilities/src/quick/_quick.scss
+++ b/packages/utilities/src/quick/_quick.scss
@@ -1,0 +1,26 @@
+@use "sass:map";
+// token maps (can import from core later)
+$space: ("0":0, "1":.25rem, "2":.5rem, "3":.75rem, "4":1rem) !default;
+
+@mixin spacing(){
+  @each $k,$v in $space {
+    .u-m-#{$k}{ margin: $v; }
+    .u-mx-#{$k}{ margin-left:$v; margin-right:$v; }
+    .u-my-#{$k}{ margin-top:$v; margin-bottom:$v; }
+    .u-p-#{$k}{ padding:$v; }
+    .u-px-#{$k}{ padding-left:$v; padding-right:$v; }
+    .u-py-#{$k}{ padding-top:$v; padding-bottom:$v; }
+  }
+}
+
+@mixin display(){
+  .u-block{display:block}.u-inline{display:inline}.u-inline-block{display:inline-block}.u-flex{display:flex}.u-grid{display:grid}
+}
+
+@mixin text(){
+  .u-text-left{text-align:left}.u-text-center{text-align:center}.u-text-right{text-align:right}
+}
+
+@mixin gridSpan($max:12){
+  @for $i from 1 through $max { .u-col-span-#{$i}{ grid-column: span #{$i}; } }
+}

--- a/packages/utilities/src/quick/default.scss
+++ b/packages/utilities/src/quick/default.scss
@@ -1,0 +1,5 @@
+@use "./quick" as q;
+@include q.spacing();
+@include q.display();
+@include q.text();
+@include q.gridSpan(12);

--- a/packages/utilities/src/scope.scss
+++ b/packages/utilities/src/scope.scss
@@ -1,0 +1,2 @@
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.show-on-focus:focus{outline:2px solid var(--color-primary);outline-offset:2px}

--- a/packages/utilities/src/steps.scss
+++ b/packages/utilities/src/steps.scss
@@ -1,0 +1,3 @@
+/* Placeholder responsive helpers; container-query variants to be added later */
+.step-hidden{display:none}
+@media (min-width:48rem){ .step-md-inline{display:inline} }

--- a/packages/utilities/vite.config.ts
+++ b/packages/utilities/vite.config.ts
@@ -1,0 +1,1 @@
+export default { build:{ lib:{ entry:"packages/utilities/src/index.scss", formats:["es"] }}}


### PR DESCRIPTION
## Summary
- scaffold @slatecss/utilities package and build config
- add quick utility generator with default bundle
- add config toggles and accessibility/responsive helpers
- prepare utilities package for publishing

## Testing
- `pnpm -F @slatecss/utilities build` *(fails: RequestAbortedError: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -F @slatecss/utilities pack` *(fails: RequestAbortedError: Proxy response (403) !== 200 when HTTP Tunneling)*
- `npm test`

Labels: Slate, Phase 4

------
https://chatgpt.com/codex/tasks/task_e_68b77b1963448329b2114bb8ed8ca290