### PR TITLE
feat(components): scaffold package and add component styles

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,1 +1,13 @@
-{ "name":"@slatecss/components", "version":"0.0.0", "type":"module" }
+{
+  "name": "@slatecss/components",
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "style": "./dist/index.css",
+  "files": [
+    "dist",
+    "src"
+  ]
+}

--- a/packages/components/src/button/_button.scss
+++ b/packages/components/src/button/_button.scss
@@ -1,0 +1,6 @@
+.btn{--bg:var(--color-primary);--fg:#fff;background:var(--bg);color:var(--fg);border:1px solid color-mix(in oklab,var(--bg),black 10%);border-radius:var(--radius-md);padding:.625rem 1rem;box-shadow:var(--shadow-sm);transition:transform var(--dur-fast) var(--ease-standard),box-shadow var(--dur-fast) var(--ease-standard)}
+.btn:hover{transform:translateY(-1px);box-shadow:var(--shadow-md)}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+.btn--ghost{background:color-mix(in oklab,var(--color-primary),white 90%);color:var(--color-primary)}
+.btn--outline{background:transparent;color:var(--color-primary);border:1px solid var(--color-primary)}
+.btn--sm{padding:.5rem .75rem}.btn--lg{padding:.75rem 1.25rem}

--- a/packages/components/src/card/_card.scss
+++ b/packages/components/src/card/_card.scss
@@ -1,0 +1,4 @@
+.card{background:var(--color-surface);color:var(--color-text);border:1px solid var(--color-border);border-radius:var(--radius-lg);box-shadow:var(--shadow-sm);overflow:hidden}
+.card__header{padding:1rem;border-bottom:1px solid var(--color-border)}
+.card__body{padding:1rem}
+.card__footer{padding:1rem;border-top:1px solid var(--color-border)}

--- a/packages/components/src/field/_field.scss
+++ b/packages/components/src/field/_field.scss
@@ -1,0 +1,6 @@
+.field{margin-bottom:1rem}.field__label{display:block;margin-bottom:.375rem;font-weight:600}
+.field__input{width:100%;padding:.625rem .75rem;border:1px solid var(--color-border);border-radius:var(--radius-sm);background:var(--color-surface);color:var(--color-text)}
+.field__input:focus{outline:2px solid var(--color-primary);outline-offset:2px}
+.field__help{color:color-mix(in oklab,var(--color-text),black 30%);font-size:.875rem;margin-top:.25rem}
+.field--error .field__input{border-color:var(--color-danger)}
+.field--error .field__help{color:var(--color-danger)}

--- a/packages/components/src/index.scss
+++ b/packages/components/src/index.scss
@@ -1,0 +1,10 @@
+@forward "motion/motion";
+@forward "tables/tables";
+@forward "modal/modal";
+@forward "stack/stack";
+@forward "tabs/tabs";
+@forward "field/field";
+@forward "card/card";
+@forward "notice/notice";
+@forward "button/button";
+/* components entry */

--- a/packages/components/src/modal/_modal.scss
+++ b/packages/components/src/modal/_modal.scss
@@ -1,0 +1,4 @@
+.modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.4);display:none}
+.modal{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);background:var(--color-surface);color:var(--color-text);border-radius:var(--radius-lg);box-shadow:var(--shadow-lg);padding:1rem;min-width:22rem;max-width:90vw;display:none}
+.modal--sm{min-width:18rem}.modal--lg{min-width:32rem}
+.modal[open], .modal-overlay[open]{display:block}

--- a/packages/components/src/motion/_motion.scss
+++ b/packages/components/src/motion/_motion.scss
@@ -1,0 +1,7 @@
+.fx-fade-in{opacity:0;transition:opacity var(--dur-med) var(--ease-standard)}
+.fx-fade-in.is-in{opacity:1}
+.fx-slide-up{transform:translateY(8px);opacity:.01;transition:transform var(--dur-med) var(--ease-standard),opacity var(--dur-med) var(--ease-standard)}
+.fx-slide-up.is-in{transform:none;opacity:1}
+.fx-scale-in{transform:scale(.98);opacity:.01;transition:transform var(--dur-med) var(--ease-standard),opacity var(--dur-med) var(--ease-standard)}
+.fx-scale-in.is-in{transform:none;opacity:1}
+@media (prefers-reduced-motion:reduce){.fx-fade-in,.fx-slide-up,.fx-scale-in{transition:none}}

--- a/packages/components/src/notice/_notice.scss
+++ b/packages/components/src/notice/_notice.scss
@@ -1,0 +1,4 @@
+.notice{border:1px solid var(--color-border);background:var(--color-surface);color:var(--color-text);border-left:4px solid var(--color-info);border-radius:var(--radius-sm);padding:.75rem 1rem;box-shadow:var(--shadow-sm)}
+.notice--success{border-left-color:var(--color-success)}
+.notice--warn{border-left-color:var(--color-warning)}
+.notice--danger{border-left-color:var(--color-danger)}

--- a/packages/components/src/stack/_stack.scss
+++ b/packages/components/src/stack/_stack.scss
@@ -1,0 +1,5 @@
+.stack{border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface)}
+.stack__item + .stack__item{border-top:1px solid var(--color-border)}
+.stack__header button{all:unset;display:block;width:100%;padding:1rem;cursor:pointer}
+.stack__panel{padding:1rem;display:none}
+.stack__item[open] .stack__panel{display:block}

--- a/packages/components/src/tables/_tables.scss
+++ b/packages/components/src/tables/_tables.scss
@@ -1,0 +1,6 @@
+.table-wrap{overflow:auto;border:1px solid var(--color-border);border-radius:var(--radius-md)}
+table.table{width:100%;border-collapse:collapse}
+.table th,.table td{padding:.75rem 1rem;border-bottom:1px solid var(--color-border)}
+.table tbody tr:nth-child(odd){background:color-mix(in oklab, var(--color-surface), black 3%)}
+.table--compact th,.table--compact td{padding:.5rem .75rem}
+.table--comfortable th,.table--comfortable td{padding:1rem 1.25rem}

--- a/packages/components/src/tabs/_tabs.scss
+++ b/packages/components/src/tabs/_tabs.scss
@@ -1,0 +1,7 @@
+.tabs{--accent:var(--color-accent, var(--color-primary))}
+.tabs__list{display:flex;gap:.5rem;border-bottom:1px solid var(--color-border)}
+.tabs__tab{padding:.5rem .75rem;border-radius:var(--radius-sm);color:var(--color-text)}
+.tabs__tab[aria-selected="true"]{color:var(--accent);box-shadow:inset 0 -2px 0 var(--accent)}
+.tabs__panel{padding:1rem}
+.tabs--vertical .tabs__list{flex-direction:column;border-bottom:0;border-right:1px solid var(--color-border)}
+@media (prefers-reduced-motion:reduce){.tabs__tab{transition:none}}

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -1,0 +1,1 @@
+export default { build:{ lib:{ entry:"packages/components/src/index.scss", formats:["es"] }}}


### PR DESCRIPTION
## Summary
- scaffold `@slatecss/components` package with Vite build and SCSS entry
- add core component styles (button, notice, card, field, tabs, stack, modal, tables, motion)
- expose package assets for publishing

## Testing
- `pnpm -F @slatecss/components build` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm -F @slatecss/components pack` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b780ba42248329a689b6315c785443