### PR TITLE
feat(cli): scaffold minimal CLI and templates

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,5 @@
+# Slate CLI
+
+Usage: `slate init <template> [target]`.
+Templates: vite, laravel, statamic, theme.
+

--- a/packages/cli/bin/cli.mjs
+++ b/packages/cli/bin/cli.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+import { mkdirSync, cpSync, existsSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const templatesDir = resolve(__dirname, '../templates');
+
+const [, , cmd, template = 'vite', target = 'slate-app'] = process.argv;
+function help(){
+  console.log(`Slate CLI
+Usage:
+  slate init <template> [target]
+Templates:
+  ${readdirSync(templatesDir).join(', ')}`);
+}
+
+if (!cmd || cmd === '--help' || cmd === '-h') { help(); process.exit(0); }
+if (cmd === 'init') {
+  const src = resolve(templatesDir, template);
+  if (!existsSync(src)) { console.error('Unknown template:', template); process.exit(1); }
+  const dest = resolve(process.cwd(), target);
+  mkdirSync(dest, { recursive: true });
+  cpSync(src, dest, { recursive: true });
+  console.log(`\u2713 Created ${template} app at ${target}`);
+  process.exit(0);
+} else {
+  help(); process.exit(1);
+}
+

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,1 +1,14 @@
-{ "name":"@slatecss/cli", "version":"0.0.0", "type":"module" }
+{
+  "name": "@slatecss/cli",
+  "version": "0.0.0",
+  "type": "module",
+  "bin": {
+    "slate": "./bin/cli.mjs"
+  },
+  "files": [
+    "bin",
+    "templates",
+    "README.md",
+    "package.json"
+  ]
+}

--- a/packages/cli/templates/laravel/README.md
+++ b/packages/cli/templates/laravel/README.md
@@ -1,0 +1,3 @@
+# Slate + Laravel
+Add Vite and import `resources/css/app.css`. Include the Blade layout in your views.
+

--- a/packages/cli/templates/laravel/resources/css/app.css
+++ b/packages/cli/templates/laravel/resources/css/app.css
@@ -1,0 +1,3 @@
+@import "../../../../packages/core/src/index.scss";
+@import "../../../../packages/components/src/index.scss";
+

--- a/packages/cli/templates/laravel/resources/views/layouts/app.blade.php
+++ b/packages/cli/templates/laravel/resources/views/layouts/app.blade.php
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Slate + Laravel</title>
+  @vite('resources/css/app.css')
+</head>
+<body class="bg">
+  <main class="card" style="margin:2rem">@yield('content')</main>
+</body>
+</html>
+

--- a/packages/cli/templates/statamic/README.md
+++ b/packages/cli/templates/statamic/README.md
@@ -1,0 +1,3 @@
+# Slate + Statamic
+Wire `resources/css/site.css` with your build tool (Vite) and extend the layout.
+

--- a/packages/cli/templates/statamic/resources/css/site.css
+++ b/packages/cli/templates/statamic/resources/css/site.css
@@ -1,0 +1,3 @@
+@import "../../../../packages/core/src/index.scss";
+@import "../../../../packages/components/src/index.scss";
+

--- a/packages/cli/templates/statamic/resources/views/layout.antlers.html
+++ b/packages/cli/templates/statamic/resources/views/layout.antlers.html
@@ -1,0 +1,7 @@
+<!doctype html><meta charset="utf-8">
+<title>{{ title or 'Slate + Statamic' }}</title>
+<link rel="stylesheet" href="/css/site.css">
+<main class="card" style="margin:2rem">
+  {{ slot }}
+</main>
+

--- a/packages/cli/templates/theme/README.md
+++ b/packages/cli/templates/theme/README.md
@@ -1,0 +1,2 @@
+# Theme skeleton for overriding tokens via @layer app.
+

--- a/packages/cli/templates/theme/package.json
+++ b/packages/cli/templates/theme/package.json
@@ -1,0 +1,2 @@
+{ "name":"@company/slate-theme","version":"0.0.0","private":true }
+

--- a/packages/cli/templates/theme/src/theme.scss
+++ b/packages/cli/templates/theme/src/theme.scss
@@ -1,0 +1,4 @@
+@layer app {
+  :root{ --color-primary:#1c4566; --radius-md:.625rem; }
+}
+

--- a/packages/cli/templates/vite/index.html
+++ b/packages/cli/templates/vite/index.html
@@ -1,0 +1,9 @@
+<!doctype html><meta charset="utf-8">
+<title>Slate + Vite</title>
+<link rel="stylesheet" href="./styles.css">
+<main class="card" style="margin:2rem">
+  <h1 class="tabs__tab" aria-selected="true">Hello Slate</h1>
+  <p class="notice notice--info">Starter ready.</p>
+  <button class="btn">Primary</button>
+</main>
+

--- a/packages/cli/templates/vite/styles.css
+++ b/packages/cli/templates/vite/styles.css
@@ -1,0 +1,4 @@
+@import "../../packages/core/src/index.scss";
+@import "../../packages/components/src/index.scss";
+body{font-family:system-ui,sans-serif}
+


### PR DESCRIPTION
## Summary
- create `@slatecss/cli` package with `slate` command and help output
- add Vite, Laravel, Statamic, and theme starter templates
- seed CHANGELOG for future releases

## Testing
- `node packages/cli/bin/cli.mjs --help`
- `npm test`
- `(cd packages/cli && npm pack)`

------
https://chatgpt.com/codex/tasks/task_e_68b78a8f13ac832996f8f83084911fab