### PR TITLE
feat(cli): scaffold minimal slate cli

### DIFF
--- a/packages/cli/bin/cli.mjs
+++ b/packages/cli/bin/cli.mjs
@@ -1,29 +1,14 @@
 #!/usr/bin/env node
 import { mkdirSync, cpSync, existsSync, readdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const templatesDir = resolve(__dirname, '../templates');
-
-const [, , cmd, template = 'vite', target = 'slate-app'] = process.argv;
-function help(){
-  console.log(`Slate CLI
+import { resolve } from 'node:path';
+const [, , cmd, template='vite', target='slate-app'] = process.argv;
+const templates = resolve(new URL('../templates', import.meta.url).pathname);
+const help=()=>console.log(`Slate CLI
 Usage:
   slate init <template> [target]
 Templates:
-  ${readdirSync(templatesDir).join(', ')}`);
-}
-
-if (!cmd || cmd === '--help' || cmd === '-h') { help(); process.exit(0); }
-if (cmd === 'init') {
-  const src = resolve(templatesDir, template);
-  if (!existsSync(src)) { console.error('Unknown template:', template); process.exit(1); }
-  const dest = resolve(process.cwd(), target);
-  mkdirSync(dest, { recursive: true });
-  cpSync(src, dest, { recursive: true });
-  console.log(`\u2713 Created ${template} app at ${target}`);
-  process.exit(0);
-} else {
-  help(); process.exit(1);
-}
-
+  ${readdirSync(templates).join(', ')}`);
+if(!cmd || /-h|--help/.test(cmd)) { help(); process.exit(0); }
+if(cmd==='init'){ const src=resolve(templates,template); if(!existsSync(src)){ console.error('Unknown template:', template); process.exit(1); }
+  const dest=resolve(process.cwd(), target); mkdirSync(dest,{recursive:true}); cpSync(src,dest,{recursive:true}); console.log(`✓ Created ${template} at ${target}`); process.exit(0);}
+help(); process.exit(1);


### PR DESCRIPTION
## Summary
- add minimal Slate CLI with `slate init <template>` command

## Testing
- `node packages/cli/bin/cli.mjs --help`
- `node packages/cli/bin/cli.mjs init vite demo-vite`
- `node packages/cli/bin/cli.mjs init laravel demo-laravel`
- `node packages/cli/bin/cli.mjs init statamic demo-statamic`
- `node packages/cli/bin/cli.mjs init theme demo-theme`
- `npm test`
- `(cd packages/cli && npm pack)`


------
https://chatgpt.com/codex/tasks/task_e_68b823789f8c83299e26d452b1bbde44