### PR TITLE
fix: review batch 1 — Base import alias, template imports, tabs test

### DIFF
--- a/packages/cli/templates/laravel/README.md
+++ b/packages/cli/templates/laravel/README.md
@@ -1,3 +1,10 @@
 # Slate + Laravel
 Add Vite and import `resources/css/app.css`. Include the Blade layout in your views.
 
+
+## Install
+
+```sh
+pnpm add -D @slatecss/core @slatecss/components
+# or: npm i -D @slatecss/core @slatecss/components
+```

--- a/packages/cli/templates/laravel/resources/css/app.css
+++ b/packages/cli/templates/laravel/resources/css/app.css
@@ -1,3 +1,3 @@
-@import "../../../../packages/core/src/index.scss";
-@import "../../../../packages/components/src/index.scss";
+@import "@slatecss/core";
+@import "@slatecss/components";
 

--- a/packages/cli/templates/statamic/README.md
+++ b/packages/cli/templates/statamic/README.md
@@ -1,3 +1,10 @@
 # Slate + Statamic
 Wire `resources/css/site.css` with your build tool (Vite) and extend the layout.
 
+
+## Install
+
+```sh
+pnpm add -D @slatecss/core @slatecss/components
+# or: npm i -D @slatecss/core @slatecss/components
+```

--- a/packages/cli/templates/statamic/resources/css/site.css
+++ b/packages/cli/templates/statamic/resources/css/site.css
@@ -1,3 +1,3 @@
-@import "../../../../packages/core/src/index.scss";
-@import "../../../../packages/components/src/index.scss";
+@import "@slatecss/core";
+@import "@slatecss/components";
 

--- a/packages/cli/templates/vite/README.md
+++ b/packages/cli/templates/vite/README.md
@@ -1,0 +1,10 @@
+# Slate + Vite
+
+Install Slate packages in your app:
+
+```sh
+pnpm add -D @slatecss/core @slatecss/components
+# or: npm i -D @slatecss/core @slatecss/components
+```
+
+Then run your bundler (Vite) — the CSS imports in `styles.css` resolve from node_modules.

--- a/packages/cli/templates/vite/styles.css
+++ b/packages/cli/templates/vite/styles.css
@@ -1,4 +1,4 @@
-@import "../../packages/core/src/index.scss";
-@import "../../packages/components/src/index.scss";
+@import "@slatecss/core";
+@import "@slatecss/components";
 body{font-family:system-ui,sans-serif}
 

--- a/sites/docs/astro.config.mjs
+++ b/sites/docs/astro.config.mjs
@@ -1,6 +1,13 @@
 import { defineConfig } from 'astro/config';
 import mdx from '@astrojs/mdx';
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const coreScss = new URL("../../packages/core/src/index.scss", import.meta.url).pathname;
+const componentsScss = new URL("../../packages/components/src/index.scss", import.meta.url).pathname;
+
 export default defineConfig({
   integrations: [mdx()],
   outDir: './dist'
+  , vite: { resolve: { alias: { "slate:core": coreScss, "slate:components": componentsScss } } }
 });

--- a/sites/docs/src/layouts/Base.astro
+++ b/sites/docs/src/layouts/Base.astro
@@ -13,8 +13,8 @@ const { title = "Slate" } = Astro.props;
       });
     </script>
     <style is:global lang="scss">
-      @import "../../../packages/core/src/index.scss";
-      @import "../../../packages/components/src/index.scss";
+      @import "slate:core";
+      @import "slate:components";
       body {
         margin: 0;
         padding: 2rem;

--- a/tests/a11y/fixtures/tabs.html
+++ b/tests/a11y/fixtures/tabs.html
@@ -1,7 +1,17 @@
 <!doctype html><meta charset="utf-8"><link rel="stylesheet" href="../../packages/components/src/index.scss">
-<div class="tabs"><div class="tabs__list">
-  <button class="tabs__tab" aria-selected="true">One</button>
-  <button class="tabs__tab" aria-selected="false">Two</button>
+<div class="tabs">
+  <div class="tabs__list">
+    <button class="tabs__tab" aria-selected="true">One</button>
+    <button class="tabs__tab" aria-selected="false">Two</button>
+  </div>
+  <section class="tabs__panel">Tab 1</section>
+  <section class="tabs__panel" hidden>Tab 2</section>
+  <script>
+    const tabs=[...document.querySelectorAll('.tabs__tab')];
+    const panels=[...document.querySelectorAll('.tabs__panel')];
+    tabs.forEach((t,i)=>t.addEventListener('click',()=>{
+      tabs.forEach((tt,j)=>tt.setAttribute('aria-selected', String(i===j)));
+      panels.forEach((p,j)=>p.toggleAttribute('hidden', i!==j));
+    }));
+  </script>
 </div>
-<section class="tabs__panel">Tab 1</section>
-<section class="tabs__panel" hidden>Tab 2</section></div>

--- a/tests/a11y/tabs.spec.ts
+++ b/tests/a11y/tabs.spec.ts
@@ -1,7 +1,17 @@
 import { test, expect } from "@playwright/test";
-// @ts-ignore: axe available in CI
-  test("tabs renders and toggles", async ({ page }) => {
-    await page.setContent(require('fs').readFileSync('tests/a11y/fixtures/tabs.html','utf8'));
-    await page.click(".tabs__tab:nth-of-type(2)");
-    await expect(await page.$(".tabs__panel[hidden]")).toBeNull();
-  });
+
+test("tabs toggles aria-selected and hidden states", async ({ page }) => {
+  const html = require('fs').readFileSync('tests/a11y/fixtures/tabs.html','utf8');
+  await page.setContent(html);
+  // initial: first selected, second hidden
+  await expect(await page.getAttribute(".tabs__tab:nth-of-type(1)", "aria-selected")).resolves?.toBe("true");
+  await expect(await page.$(".tabs__panel:nth-of-type(2)[hidden]")).not.toBeNull();
+  // click second tab
+  await page.click(".tabs__tab:nth-of-type(2)");
+  // now: second selected, first hidden
+  await expect(await page.getAttribute(".tabs__tab:nth-of-type(2)", "aria-selected")).resolves?.toBe("true");
+  const firstHidden = await page.$(".tabs__panel:nth-of-type(1)[hidden]");
+  const secondVisible = await page.$(".tabs__panel:nth-of-type(2):not([hidden])");
+  await expect(firstHidden).not.toBeNull();
+  await expect(secondVisible).not.toBeNull();
+});


### PR DESCRIPTION
## Summary
- add Vite aliases for core and components SCSS and use them in docs Base layout
- switch template CSS to @slatecss package imports and document installation
- fix tabs fixture and test to toggle selected/hidden states

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8269c9254832995752b4a9b5d2c1c