### PR TITLE
feat(migration): mapping, shims package, and docs

### DIFF
--- a/packages/shims/README.md
+++ b/packages/shims/README.md
@@ -1,0 +1,3 @@
+# @slatecss/shims
+
+Temporary helpers for migrating from Foundation to Slate.

--- a/packages/shims/package.json
+++ b/packages/shims/package.json
@@ -1,0 +1,1 @@
+{"name":"@slatecss/shims","version":"0.0.0","type":"module","exports":{".":{"import":"./dist/index.js"}},"style":"./dist/index.css","files":["dist","src","package.json","README.md"]}

--- a/packages/shims/src/index.scss
+++ b/packages/shims/src/index.scss
@@ -1,0 +1,8 @@
+/* Foundation → Slate aliases (subset) */
+.top-bar { @extend .tabs__list !optional; }
+.button { @extend .btn !optional; }
+.callout, .alert-box { @extend .notice !optional; }
+.reveal { @extend .modal !optional; }
+.accordion { @extend .stack !optional; }
+.tabs-content { @extend .tabs__panel !optional; }
+@for $i from 1 through 12 { .small-#{$i} { grid-column: span #{$i}; } }

--- a/packages/shims/src/index.ts
+++ b/packages/shims/src/index.ts
@@ -1,0 +1,10 @@
+const once = new Set<string>();
+const warn = (m:string)=>{ if(!once.has(m)){ once.add(m); console.warn(`[Slate shims] ${m}`);} };
+export function scanAndWarn(root: ParentNode = document){
+  ([
+    ['.top-bar','SwitchNav'], ['.reveal','Modal'], ['.accordion','Stack'], ['.button','Button'], ['.callout,.alert-box','Notice']
+  ] as [string,string][]).forEach(([sel,name])=>{
+    if ((root as Document).querySelector(sel)) warn(`Legacy selector "${sel}" detected; prefer ${name}.`);
+  });
+}
+if (typeof window !== 'undefined') window.addEventListener('DOMContentLoaded',()=>scanAndWarn());

--- a/sites/docs/src/migration/foundation-table.md
+++ b/sites/docs/src/migration/foundation-table.md
@@ -1,0 +1,27 @@
+# Foundation → Slate Mapping
+| Foundation | Slate | Notes |
+|---|---|---|
+| Grid (Block/XY) | Matrix | `@include matrix(...)`, `.u-col-span-*` |
+| Top Bar / Responsive Menu | SwitchNav | auto menu↔drawer |
+| Off-Canvas | SideNav | drawer + overlay |
+| Dropdown | Dropdown | (planned v1.1) |
+| Mega Menu | Spread | wide/flyout |
+| Button | Button | `.btn` variants |
+| Badge/Label | Tag | (planned) |
+| Forms | Field | error states |
+| Tables | Tables | zebra/compact |
+| Alert | Notice | success/warn/danger |
+| Toast | Ping | (planned) |
+| Modal | Modal | focus trap (JS) |
+| Accordion | Stack | details visuals |
+| Tabs | Tabs | aria-selected |
+| Tooltip/Popover | Hint | (planned) |
+| Motion UI | Pulse/Shifts | CSS motion |
+| Visibility Classes | Scope | sr-only, etc. |
+| Responsive Helpers | Steps | step-* helpers |
+| Equalizer | Balance | equal-height |
+| Stepper/Wizard | Path | (planned) |
+| Command Palette | Echo | (planned) |
+| Breadcrumbs | Trail | (planned) |
+| Pagination | Pagination | (planned) |
+| Drawer | Pocket | (planned) |

--- a/sites/docs/src/migration/shims.astro
+++ b/sites/docs/src/migration/shims.astro
@@ -1,0 +1,14 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Shims">
+  <h1>Shims for Foundation → Slate</h1>
+  <p>Temporary CSS/JS helpers to ease migration. Remove after updating templates.</p>
+  <h2>Install</h2>
+  <pre><code>pnpm add -D @slatecss/shims</code></pre>
+  <h2>Use</h2>
+  <pre><code>@import "@slatecss/shims"; // CSS
+import "@slatecss/shims";     // JS</code></pre>
+  <h2>Removal checklist</h2>
+  <ul><li>Replace legacy selectors</li><li>Drop shims imports</li><li>Fix remaining console warnings</li></ul>
+</Base>

--- a/sites/docs/src/pages/index.astro
+++ b/sites/docs/src/pages/index.astro
@@ -6,4 +6,5 @@ import Base from "../layouts/Base.astro";
   <p>Lightweight, token-driven framework.</p>
   <p><a href="/playground">Playground</a> · <a href="/tokens">Tokens</a></p>
   <p><a href="/components">Components</a></p>
+  <p><a href="/migration/foundation-table">Migration: Foundation → Slate</a></p>
 </Base>


### PR DESCRIPTION
## Summary
- document Foundation → Slate mapping
- add shims package for legacy selectors
- document shims and link from docs index

## Testing
- `npm run build`
- `npm run verify:dist`

Labels: Slate, Phase 11

------
https://chatgpt.com/codex/tasks/task_e_68b8415d263083298d22767ea24198db