### PR TITLE
ci(docs): add docs diagnostics and hard guard

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: Docs
 on:
-  push: { branches: [ main ] }
+  push:
+    branches:
+      - main
   workflow_dispatch:
 permissions:
   contents: read
@@ -14,13 +16,30 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
-      - run: corepack enable || true
-      - run: corepack prepare pnpm@10.5.2 --activate || true
-      - run: pnpm -v || echo "pnpm unavailable; fallback to npm"
-      - run: cd sites/docs && (pnpm install || npm install) || true
-      - run: cd sites/docs && (pnpm run build || npm run build || echo "build failed")
-      - name: ensure-dist
-        run: test -d sites/docs/dist || (mkdir -p sites/docs/dist && echo "<!doctype html><meta charset=\"utf-8\"><title>Slate Docs</title><h1>Placeholder</h1>" > sites/docs/dist/index.html)
+      - run: corepack enable
+      - run: corepack prepare pnpm@10.5.2 --activate
+      - run: pnpm -v
+      - working-directory: sites/docs
+        run: pnpm install || npm install
+      - working-directory: sites/docs
+        run: pnpm run build || npm run build
+      - name: Inspect dist
+        run: |
+          echo '--- dist listing ---'
+          ls -lah sites/docs/dist
+          echo '--- index.html (first 60 lines) ---'
+          head -n 60 sites/docs/dist/index.html
+      - name: Guard: dist must not be placeholder
+        run: |
+          test -f sites/docs/dist/index.html
+          if grep -qi 'placeholder' sites/docs/dist/index.html; then
+            echo 'Placeholder detected in index.html'; exit 1;
+          fi
+          BYTES=$(wc -c < sites/docs/dist/index.html || echo 0)
+          if [ "$BYTES" -lt 500 ]; then
+            echo 'index.html suspiciously small ('$BYTES' bytes)'; exit 1;
+          fi
+      - run: node scripts/docs-diagnose.mjs
       - uses: actions/upload-pages-artifact@v3
         with: { path: "sites/docs/dist" }
   deploy:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "build:js": "pnpm -F @slatecss/js build || true",
     "size": "size-limit",
     "verify:dist": "node scripts/verify-dists.mjs",
-    "smoke:shims": "node scripts/smoke-shims.mjs"
+    "smoke:shims": "node scripts/smoke-shims.mjs",
+    "docs:diagnose": "node scripts/docs-diagnose.mjs"
   },
   "devDependencies": {
     "size-limit": "^11.0.0"

--- a/scripts/docs-diagnose.mjs
+++ b/scripts/docs-diagnose.mjs
@@ -1,0 +1,18 @@
+import { readFileSync, existsSync } from 'node:fs';
+const out = [];
+function ok(m){ out.push('✅ '+m); }
+function bad(m){ out.push('❌ '+m); process.exitCode=1; }
+// Astro base
+const astro = readFileSync('sites/docs/astro.config.mjs','utf8');
+/base:\s*'\/Slate'/.test(astro) ? ok('Astro base=/Slate') : bad('Astro base not /Slate');
+// Docs trigger
+const docs = readFileSync('.github/workflows/docs.yml','utf8');
+/push:[\s\S]*branches:[\s\S]*-\s*main/.test(docs) ? ok('Docs workflow triggers on push: main') : bad('Docs workflow does not trigger on push: main');
+// Placeholder step removed
+/ensure-dist/.test(docs) ? bad('Placeholder ensure-dist step still present') : ok('No ensure-dist step present');
+// Components link
+const home = readFileSync('sites/docs/src/pages/index.astro','utf8');
+/\/components/.test(home) ? ok('Home links to /components') : bad('Home missing /components link');
+// Components pages exist (one sample)
+existsSync('sites/docs/src/pages/components/button.astro') ? ok('Components gallery present') : bad('Components gallery missing');
+console.log('--- Slate Docs Diagnostics ---\n'+out.join('\n'));

--- a/sites/docs/astro.config.mjs
+++ b/sites/docs/astro.config.mjs
@@ -6,7 +6,7 @@ const coreScss = new URL("../../packages/core/src/index.scss", import.meta.url).
 const componentsScss = new URL("../../packages/components/src/index.scss", import.meta.url).pathname;
 
 export default defineConfig({
-  base: "/Slate",
+  base: '/Slate',
   
   outDir: './dist'
   , vite: { resolve:{ alias:{ "slate:js": new URL("../../packages/js/src/index.ts", import.meta.url).pathname,  "slate:core": coreScss, "slate:components": componentsScss } } }


### PR DESCRIPTION
## Summary
- ensure Astro base path is '/Slate'
- add docs diagnostics script and workflow instrumentation
- check dist index.html for placeholders

## Testing
- `npm test`
- `npm run docs:diagnose`


------
https://chatgpt.com/codex/tasks/task_e_68bca70cfc108329ba447786c3375e2e