### PR TITLE
ci(docs): replace conflicted workflow with clean, validated YAML

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,17 @@
 name: Docs
 on:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
+
 permissions:
   contents: read
   pages: write
   id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -17,25 +21,34 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
 
-      # Prefer pnpm, fall back to npm
+      # Prefer pnpm; fall back to npm
       - run: corepack enable || true
       - run: corepack prepare pnpm@10.5.2 --activate || true
+      - name: Print versions
+        run: |
+          node -v
+          npm -v
+          pnpm -v || true
+          npx astro --version || true
+
       - name: Install (sites/docs)
+        working-directory: sites/docs
         run: |
           if command -v pnpm >/dev/null 2>&1; then
-            pnpm -C sites/docs install --frozen-lockfile
+            pnpm install --frozen-lockfile
           else
-            npm ci --prefix sites/docs
+            npm ci
           fi
 
       - name: Build (sites/docs)
+        working-directory: sites/docs
         run: |
           if command -v pnpm >/dev/null 2>&1; then
-            pnpm -C sites/docs run build
+            pnpm run build
           else
-            npm run --prefix sites/docs build
+            npm run build
           fi
 
       - name: Inspect dist
@@ -43,9 +56,9 @@ jobs:
           echo '--- dist listing ---'
           ls -lah sites/docs/dist
           echo '--- index.html (first 60 lines) ---'
-          head -n 60 sites/docs/dist/index.html
+          head -n 60 sites/docs/dist/index.html || true
 
-      - name: Guard: dist must not be placeholder
+      - name: "Guard: dist must not be placeholder"
         run: |
           test -f sites/docs/dist/index.html
           if grep -qi 'placeholder' sites/docs/dist/index.html; then


### PR DESCRIPTION
## Summary
- simplify docs workflow for Astro build and GitHub Pages deploy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcb18c7b308329a1c263c801c0dd71