### PR TITLE
docs: bundle boot script and base-aware links for docs

### DIFF
--- a/sites/docs/astro.config.mjs
+++ b/sites/docs/astro.config.mjs
@@ -6,7 +6,8 @@ const coreScss = new URL("../../packages/core/src/index.scss", import.meta.url).
 const componentsScss = new URL("../../packages/components/src/index.scss", import.meta.url).pathname;
 
 export default defineConfig({
-  base: "/Slate",
+  site: "https://joshtipton28.github.io/Slate",
+  base: '/Slate',
   
   outDir: './dist'
   , vite: { resolve:{ alias:{ "slate:js": new URL("../../packages/js/src/index.ts", import.meta.url).pathname,  "slate:core": coreScss, "slate:components": componentsScss } } }

--- a/sites/docs/src/layouts/Base.astro
+++ b/sites/docs/src/layouts/Base.astro
@@ -6,16 +6,10 @@ const { title = "Slate" } = Astro.props;
   <head>
     <meta charset="utf-8" />
     <title>{title}</title>
-    <script type="module">
-      import { initThemeToggle } from "/src/components/ThemeToggle.ts";
-      window.addEventListener('DOMContentLoaded', () => {
-        const btn = document.querySelector('#theme-toggle');
-        if (btn) initThemeToggle(btn);
-      });
-    </script>
+    
     <style is:global lang="scss">
-      @import "slate:core";
-      @import "slate:components";
+      @import "../../../../packages/core/src/index.scss";
+      @import "../../../../packages/components/src/index.scss";
       body {
         margin: 0;
         padding: 2rem;
@@ -24,7 +18,7 @@ const { title = "Slate" } = Astro.props;
         font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
       }
     </style>
-  <script type="module" src="/src/scripts/boot.ts"></script>
+      <script type="module" src={Astro.resolve('../scripts/boot.ts')}></script>
     </head>
   <body>
     <header style="display:flex;justify-content:space-between;align-items:center;padding:1rem">

--- a/sites/docs/src/pages/components/index.astro
+++ b/sites/docs/src/pages/components/index.astro
@@ -16,6 +16,6 @@ const items = [
 <Base title="Components">
   <h1>Components</h1>
   <ul>
-    {items.map(([t,href]) => <li><a href={href}>{t}</a></li>)}
+    {items.map(([t,href]) => <li><a href={Astro.url(href)}>{t}</a></li>)}
   </ul>
 </Base>

--- a/sites/docs/src/pages/index.astro
+++ b/sites/docs/src/pages/index.astro
@@ -4,7 +4,7 @@ import Base from "../layouts/Base.astro";
 <Base title="Slate">
   <h1>Slate</h1>
   <p>Lightweight, token-driven framework.</p>
-  <p><a href="/playground">Playground</a> · <a href="/tokens">Tokens</a></p>
-  <p><a href="/components">Components</a></p>
-  <p><a href="/migration/foundation-table">Migration: Foundation → Slate</a></p>
+  <p><a href={Astro.url('/playground')}>Playground</a> · <a href={Astro.url('/tokens')}>Tokens</a></p>
+  <p><a href={Astro.url('/components')}>Components</a></p>
+  <p><a href={Astro.url('/migration/foundation-table')}>Migration: Foundation → Slate</a></p>
 </Base>

--- a/sites/docs/src/scripts/boot.ts
+++ b/sites/docs/src/scripts/boot.ts
@@ -1,24 +1,33 @@
 import { initTabs } from "../../../../packages/js/src/tabs";
 import { initStack } from "../../../../packages/js/src/stack";
 import { open as openModal, close as closeModal } from "../../../../packages/js/src/modal";
-window.addEventListener("DOMContentLoaded", () => {
-  document.querySelectorAll<HTMLElement>(".tabs").forEach(initTabs);
-  document.querySelectorAll<HTMLElement>(".stack").forEach(initStack);
-  document.querySelectorAll<HTMLElement>("[data-open-modal]").forEach(btn => {
+import { initThemeToggle } from "../components/ThemeToggle.ts";
+
+window.addEventListener('DOMContentLoaded', () => {
+  // Tabs / Stack (demos)
+  document.querySelectorAll<HTMLElement>(".tabs")?.forEach(initTabs);
+  document.querySelectorAll<HTMLElement>(".stack")?.forEach(initStack);
+
+  // Modal demo
+  document.querySelectorAll<HTMLElement>("[data-open-modal]")?.forEach(btn => {
     btn.addEventListener("click", () => {
       const id = btn.getAttribute("data-open-modal")!;
       const el = document.getElementById(id)!;
       const overlay = document.querySelector<HTMLElement>(".modal-overlay");
       openModal(el as HTMLElement);
-      overlay?.setAttribute("open","");
-      overlay?.addEventListener("click", () => { closeModal(el as HTMLElement); overlay?.removeAttribute("open"); }, { once:true });
+      overlay?.setAttribute("open", "");
+      overlay?.addEventListener("click", () => { closeModal(el as HTMLElement); overlay?.removeAttribute("open"); }, { once: true });
     });
   });
-  document.querySelectorAll("[data-close-modal]").forEach(btn => {
+  document.querySelectorAll("[data-close-modal]")?.forEach(btn => {
     btn.addEventListener("click", () => {
       const el = (btn as HTMLElement).closest<HTMLElement>(".modal")!;
       closeModal(el);
       document.querySelector<HTMLElement>(".modal-overlay")?.removeAttribute("open");
     });
   });
+
+  // Theme toggle
+  const btn = document.querySelector<HTMLButtonElement>('#theme-toggle');
+  if (btn) initThemeToggle(btn);
 });


### PR DESCRIPTION
## Summary
- bundle docs boot script through Astro.resolve and load ThemeToggle from boot.ts
- set site and base to GitHub Pages path
- switch docs links to use `Astro.url` for base awareness

## Testing
- `npm run lint`
- `npm run docs:diagnose`


------
https://chatgpt.com/codex/tasks/task_e_68bccd21f92083299e2ca6f086af867d