### PR TITLE
docs: replace Astro.url() calls with base-aware withBase() helper for links

### DIFF
--- a/sites/docs/src/pages/components/index.astro
+++ b/sites/docs/src/pages/components/index.astro
@@ -1,4 +1,5 @@
 ---
+const withBase = (p) => (import.meta.env.BASE_URL || "/").replace(/\/$/, "") + "/" + String(p).replace(/^\//, "");
 import Base from "../../layouts/Base.astro";
 const items = [
   ["Buttons","/components/button"],
@@ -16,6 +17,6 @@ const items = [
 <Base title="Components">
   <h1>Components</h1>
   <ul>
-    {items.map(([t,href]) => <li><a href={Astro.url(href)}>{t}</a></li>)}
+    {items.map(([t,href]) => <li><a href={withBase(href)}>{t}</a></li>)}
   </ul>
 </Base>

--- a/sites/docs/src/pages/index.astro
+++ b/sites/docs/src/pages/index.astro
@@ -1,10 +1,11 @@
 ---
+const withBase = (p) => (import.meta.env.BASE_URL || "/").replace(/\/$/, "") + "/" + String(p).replace(/^\//, "");
 import Base from "../layouts/Base.astro";
 ---
 <Base title="Slate">
   <h1>Slate</h1>
   <p>Lightweight, token-driven framework.</p>
-  <p><a href={Astro.url('/playground')}>Playground</a> · <a href={Astro.url('/tokens')}>Tokens</a></p>
-  <p><a href={Astro.url('/components')}>Components</a></p>
-  <p><a href={Astro.url('/migration/foundation-table')}>Migration: Foundation → Slate</a></p>
+  <p><a href={withBase('/playground')}>Playground</a> · <a href={withBase('/tokens')}>Tokens</a></p>
+  <p><a href={withBase('/components')}>Components</a></p>
+  <p><a href={withBase('/migration/foundation-table')}>Migration: Foundation → Slate</a></p>
 </Base>


### PR DESCRIPTION
## Summary
- add withBase() helper to docs index pages to build links from Astro's base
- replace Astro.url() with withBase() for component links

## Testing
- `npm run lint || true`
- `npm run docs:diagnose || true`


------
https://chatgpt.com/codex/tasks/task_e_68bccf7dac8083299c015a37537d02b4