### PR TITLE
docs: bundle Slate styles and boot script locally

### DIFF
--- a/sites/docs/astro.config.mjs
+++ b/sites/docs/astro.config.mjs
@@ -6,8 +6,8 @@ const coreScss = new URL("../../packages/core/src/index.scss", import.meta.url).
 const componentsScss = new URL("../../packages/components/src/index.scss", import.meta.url).pathname;
 
 export default defineConfig({
-  site: "https://joshtipton28.github.io/Slate",
   base: '/Slate',
+  site: 'https://joshtipton28.github.io/Slate',
   
   outDir: './dist'
   , vite: { resolve:{ alias:{ "slate:js": new URL("../../packages/js/src/index.ts", import.meta.url).pathname,  "slate:core": coreScss, "slate:components": componentsScss } } }

--- a/sites/docs/package.json
+++ b/sites/docs/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build"
+    "build": "astro build",
+    "prebuild": "node scripts/build-vendor.mjs"
   },
   "devDependencies": {
     "astro": "^4.12.2",

--- a/sites/docs/scripts/build-vendor.mjs
+++ b/sites/docs/scripts/build-vendor.mjs
@@ -1,0 +1,31 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '../../..'); // repo root
+const entries = [
+  resolve(root, 'packages/core/src/index.scss'),
+  resolve(root, 'packages/components/src/index.scss'),
+  resolve(root, 'packages/utilities/src/index.scss'),
+];
+
+let sass;
+try { sass = (await import('sass')).default; }
+catch { console.error('[docs] Missing devDependency "sass" in sites/docs. Add it in package.json.'); process.exit(1); }
+
+const parts = [];
+for (const inFile of entries) {
+  try {
+    const css = sass.compile(inFile, { style: 'expanded', loadPaths: [dirname(inFile)] }).css;
+    parts.push(css);
+    console.log('[docs] compiled', inFile);
+  } catch (e) {
+    console.warn('[docs] failed to compile', inFile, e.message);
+  }
+}
+
+const out = resolve(__dirname, '../src/styles/slate.css');
+mkdirSync(dirname(out), { recursive: true });
+writeFileSync(out, parts.join('\n\n'));
+console.log('[docs] wrote', out);

--- a/sites/docs/src/layouts/Base.astro
+++ b/sites/docs/src/layouts/Base.astro
@@ -1,4 +1,6 @@
 ---
+import '../scripts/boot.ts';
+import '../styles/slate.css';
 const { title = "Slate" } = Astro.props;
 ---
 
@@ -6,20 +8,7 @@ const { title = "Slate" } = Astro.props;
   <head>
     <meta charset="utf-8" />
     <title>{title}</title>
-    
-    <style is:global lang="scss">
-      @import "../../../../packages/core/src/index.scss";
-      @import "../../../../packages/components/src/index.scss";
-      body {
-        margin: 0;
-        padding: 2rem;
-        background: var(--color-bg);
-        color: var(--color-text);
-        font-family: system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
-      }
-    </style>
-      <script type="module" src={Astro.resolve('../scripts/boot.ts')}></script>
-    </head>
+  </head>
   <body>
     <header style="display:flex;justify-content:space-between;align-items:center;padding:1rem">
       <h1>Slate</h1>

--- a/sites/docs/src/styles/slate.css
+++ b/sites/docs/src/styles/slate.css
@@ -1,0 +1,357 @@
+:root {
+  --font-sans:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  font-size: 16px;
+}
+
+h1 {
+  font-family: var(--font-sans);
+  font-size: clamp(2.25rem, 4vw, 3rem);
+}
+
+h2 {
+  font-family: var(--font-sans);
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+}
+
+h3 {
+  font-family: var(--font-sans);
+  font-size: clamp(1.5rem, 2.5vw, 1.875rem);
+}
+
+:root {
+  --brand-echo-light:#b8d2ed;
+  --brand-slate-muted:#566590;
+  --brand-indigogray:#42436c;
+  --brand-teal-deep:#1c4566;
+  --brand-slate-dark:#323460;
+  --brand-navy-midnight:#03284f;
+  --color-bg:#f7f8fa;
+  --color-surface:#ffffff;
+  --color-border:#e5e9f2;
+  --color-text:#0f1220;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg:#0e121b;
+    --color-surface:#121826;
+    --color-border:#1f293b;
+    --color-text:#e8edf7;
+  }
+}
+[data-theme=dark] {
+  --color-bg:#0e121b;
+  --color-surface:#121826;
+  --color-border:#1f293b;
+  --color-text:#e8edf7;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+}
+
+h1, h2, h3 {
+  font-weight: 700;
+}
+
+p {
+  line-height: 1.6;
+}
+
+.fx-fade-in {
+  opacity: 0;
+  transition: opacity var(--dur-med) var(--ease-standard);
+}
+
+.fx-fade-in.is-in {
+  opacity: 1;
+}
+
+.fx-slide-up {
+  transform: translateY(8px);
+  opacity: 0.01;
+  transition: transform var(--dur-med) var(--ease-standard), opacity var(--dur-med) var(--ease-standard);
+}
+
+.fx-slide-up.is-in {
+  transform: none;
+  opacity: 1;
+}
+
+.fx-scale-in {
+  transform: scale(0.98);
+  opacity: 0.01;
+  transition: transform var(--dur-med) var(--ease-standard), opacity var(--dur-med) var(--ease-standard);
+}
+
+.fx-scale-in.is-in {
+  transform: none;
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fx-fade-in, .fx-slide-up, .fx-scale-in {
+    transition: none;
+  }
+}
+.table-wrap {
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+table.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table th, .table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.table tbody tr:nth-child(odd) {
+  background: color-mix(in oklab, var(--color-surface), black 3%);
+}
+
+.table--compact th, .table--compact td {
+  padding: 0.5rem 0.75rem;
+}
+
+.table--comfortable th, .table--comfortable td {
+  padding: 1rem 1.25rem;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  padding: 1rem;
+  min-width: 22rem;
+  max-width: 90vw;
+  display: none;
+}
+
+.modal--sm {
+  min-width: 18rem;
+}
+
+.modal--lg {
+  min-width: 32rem;
+}
+
+.modal[open], .modal-overlay[open] {
+  display: block;
+}
+
+.stack {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+}
+
+.stack__item + .stack__item {
+  border-top: 1px solid var(--color-border);
+}
+
+.stack__header button {
+  all: unset;
+  display: block;
+  width: 100%;
+  padding: 1rem;
+  cursor: pointer;
+}
+
+.stack__panel {
+  padding: 1rem;
+  display: none;
+}
+
+.stack__item[open] .stack__panel {
+  display: block;
+}
+
+.tabs {
+  --accent:var(--color-accent, var(--color-primary));
+}
+
+.tabs__list {
+  display: flex;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tabs__tab {
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+}
+
+.tabs__tab[aria-selected=true] {
+  color: var(--accent);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+
+.tabs__panel {
+  padding: 1rem;
+}
+
+.tabs--vertical .tabs__list {
+  flex-direction: column;
+  border-bottom: 0;
+  border-right: 1px solid var(--color-border);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs__tab {
+    transition: none;
+  }
+}
+.field {
+  margin-bottom: 1rem;
+}
+
+.field__label {
+  display: block;
+  margin-bottom: 0.375rem;
+  font-weight: 600;
+}
+
+.field__input {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.field__input:focus {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.field__help {
+  color: color-mix(in oklab, var(--color-text), black 30%);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.field--error .field__input {
+  border-color: var(--color-danger);
+}
+
+.field--error .field__help {
+  color: var(--color-danger);
+}
+
+.card {
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.card__header {
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card__body {
+  padding: 1rem;
+}
+
+.card__footer {
+  padding: 1rem;
+  border-top: 1px solid var(--color-border);
+}
+
+.notice {
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-left: 4px solid var(--color-info);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.notice--success {
+  border-left-color: var(--color-success);
+}
+
+.notice--warn {
+  border-left-color: var(--color-warning);
+}
+
+.notice--danger {
+  border-left-color: var(--color-danger);
+}
+
+.btn {
+  --bg:var(--color-primary);
+  --fg:#fff;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid color-mix(in oklab, var(--bg), black 10%);
+  border-radius: var(--radius-md);
+  padding: 0.625rem 1rem;
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--dur-fast) var(--ease-standard), box-shadow var(--dur-fast) var(--ease-standard);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn--ghost {
+  background: color-mix(in oklab, var(--color-primary), white 90%);
+  color: var(--color-primary);
+}
+
+.btn--outline {
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+}
+
+.btn--sm {
+  padding: 0.5rem 0.75rem;
+}
+
+.btn--lg {
+  padding: 0.75rem 1.25rem;
+}
+
+/* components entry */


### PR DESCRIPTION
## Summary
- compile package SCSS into docs' `src/styles/slate.css`
- run prebuild before docs build with `sass` dependency
- load local `slate.css` and `boot.ts` in `Base.astro`
- set docs `base` and `site` in `astro.config.mjs`

## Testing
- `npm run docs:selfcheck`
- `npm run docs:diagnose`

------
https://chatgpt.com/codex/tasks/task_e_68bcd56bca0c8329b566c6266651916d