### PR TITLE
docs: add container styles and scaffold polished component demos

### DIFF
--- a/sites/docs/src/layouts/Base.astro
+++ b/sites/docs/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 const { title = 'Slate' } = Astro.props;
 /* Import local, bundled assets so Vite/Astro injects them correctly */
 import '../styles/slate.css';
+import '../styles/docs.css';
 import bootUrl from '../scripts/boot.ts?url';
 ---
 <!doctype html>

--- a/sites/docs/src/pages/components/button.astro
+++ b/sites/docs/src/pages/components/button.astro
@@ -1,12 +1,27 @@
 ---
 import Base from "../../layouts/Base.astro";
 ---
-<Base title="Button">
-  <h1>Button</h1>
-  <p>Variants:</p>
-  <button class="btn">Primary</button>
-  <button class="btn btn--ghost">Ghost</button>
-  <button class="btn btn--outline">Outline</button>
-  <button class="btn btn--sm">Small</button>
-  <button class="btn btn--lg">Large</button>
+<Base title="Buttons">
+  <div class="container stack--lg">
+    <h1>Buttons</h1>
+    <div class="grid">
+      <div class="demo-card stack">
+        <h3>Solid</h3>
+        <button class="btn">Primary</button>
+        <button class="btn btn--secondary">Secondary</button>
+        <button class="btn btn--danger">Danger</button>
+      </div>
+      <div class="demo-card stack">
+        <h3>Ghost / Outline</h3>
+        <button class="btn btn--ghost">Ghost</button>
+        <button class="btn btn--outline">Outline</button>
+      </div>
+      <div class="demo-card stack">
+        <h3>Sizes</h3>
+        <button class="btn btn--sm">Small</button>
+        <button class="btn">Default</button>
+        <button class="btn btn--lg">Large</button>
+      </div>
+    </div>
+  </div>
 </Base>

--- a/sites/docs/src/pages/components/card.astro
+++ b/sites/docs/src/pages/components/card.astro
@@ -1,10 +1,9 @@
 ---
 import Base from "../../layouts/Base.astro";
 ---
-<Base title="Card">
-  <article class="card" style="max-width: 480px;">
-    <header class="card__header">Header</header>
-    <div class="card__body">Body</div>
-    <footer class="card__footer">Footer</footer>
-  </article>
+<Base title="Cards">
+  <div class="container grid">
+    <article class="card"><header class="card__header">Header</header><div class="card__body">Body</div><footer class="card__footer">Footer</footer></article>
+    <article class="card"><div class="card__body">Minimal card</div></article>
+  </div>
 </Base>

--- a/sites/docs/src/pages/components/field.astro
+++ b/sites/docs/src/pages/components/field.astro
@@ -1,15 +1,16 @@
 ---
 import Base from "../../layouts/Base.astro";
 ---
-<Base title="Field">
-  <div class="field">
-    <label class="field__label" for="email">Email</label>
-    <input class="field__input" id="email" type="email" placeholder="you@example.com" />
-    <small class="field__help">We’ll never share your email.</small>
-  </div>
-  <div class="field field--error">
-    <label class="field__label" for="name">Name</label>
-    <input class="field__input" id="name" />
-    <small class="field__help">Name is required.</small>
+<Base title="Fields">
+  <div class="container grid">
+    <div class="demo-card">
+      <label class="field__label" for="email">Email</label>
+      <input class="field__input" id="email" type="email" placeholder="you@example.com" />
+      <div class="field__help">We never share your email.</div>
+    </div>
+    <div class="demo-card">
+      <label class="field__label" for="sel">Select</label>
+      <select class="field__input" id="sel"><option>One</option><option>Two</option></select>
+    </div>
   </div>
 </Base>

--- a/sites/docs/src/pages/components/grid.astro
+++ b/sites/docs/src/pages/components/grid.astro
@@ -1,9 +1,13 @@
 ---
 import Base from "../../layouts/Base.astro";
 ---
-<Base title="Grid (Matrix)">
-  <div style="display:grid;grid-template-columns:repeat(12,minmax(0,1fr));gap:1rem;">
-    <div class="card u-p-2" style="grid-column:span 3;">Span 3</div>
-    <div class="card u-p-2" style="grid-column:span 9;">Span 9</div>
+<Base title="Matrix (Grid)">
+  <div class="container">
+    <div class="grid">
+      <div class="demo-card">Cell 1</div>
+      <div class="demo-card">Cell 2</div>
+      <div class="demo-card">Cell 3</div>
+      <div class="demo-card">Cell 4</div>
+    </div>
   </div>
 </Base>

--- a/sites/docs/src/pages/components/modal.astro
+++ b/sites/docs/src/pages/components/modal.astro
@@ -2,13 +2,15 @@
 import Base from "../../layouts/Base.astro";
 ---
 <Base title="Modal">
-  <button class="btn" data-open-modal="demo-modal">Open modal</button>
-  <div class="modal-overlay"></div>
-  <div id="demo-modal" class="modal" role="dialog" aria-modal="true">
-    <header class="card__header">Modal</header>
-    <div class="card__body">Hello!</div>
-    <footer class="card__footer">
-      <button class="btn btn--ghost" data-close-modal>Close</button>
-    </footer>
+  <div class="container">
+    <button class="btn" data-open-modal="demo-modal">Open modal</button>
+    <div class="modal-overlay"></div>
+    <div id="demo-modal" class="modal" aria-modal="true" role="dialog" hidden>
+      <div class="modal__dialog">
+        <header class="modal__header">Modal</header>
+        <div class="modal__body">Hello from Slate modal.</div>
+        <footer class="modal__footer"><button class="btn" data-close-modal>Close</button></footer>
+      </div>
+    </div>
   </div>
 </Base>

--- a/sites/docs/src/pages/components/notice.astro
+++ b/sites/docs/src/pages/components/notice.astro
@@ -1,9 +1,11 @@
 ---
 import Base from "../../layouts/Base.astro";
 ---
-<Base title="Notice">
-  <div class="notice">Info notice</div>
-  <div class="notice notice--success">Success notice</div>
-  <div class="notice notice--warn">Warning notice</div>
-  <div class="notice notice--danger">Danger notice</div>
+<Base title="Notices">
+  <div class="container grid">
+    <div class="demo-card notice notice--info">Info notice</div>
+    <div class="demo-card notice notice--success">Success notice</div>
+    <div class="demo-card notice notice--warn">Warning notice</div>
+    <div class="demo-card notice notice--danger">Danger notice</div>
+  </div>
 </Base>

--- a/sites/docs/src/pages/components/stack.astro
+++ b/sites/docs/src/pages/components/stack.astro
@@ -1,13 +1,13 @@
 ---
 import Base from "../../layouts/Base.astro";
 ---
-<Base title="Stack">
-  <details class="stack__item" open>
-    <summary class="stack__header"><button aria-expanded="true">Section 1</button></summary>
-    <div class="stack__panel">Content 1</div>
-  </details>
-  <details class="stack__item">
-    <summary class="stack__header"><button aria-expanded="false">Section 2</button></summary>
-    <div class="stack__panel">Content 2</div>
-  </details>
+<Base title="Stack (Accordion)">
+  <div class="container">
+    <div class="stack" data-accordion>
+      <button class="stack__header">Section A</button>
+      <div class="stack__panel">A content</div>
+      <button class="stack__header">Section B</button>
+      <div class="stack__panel">B content</div>
+    </div>
+  </div>
 </Base>

--- a/sites/docs/src/pages/components/tables.astro
+++ b/sites/docs/src/pages/components/tables.astro
@@ -2,13 +2,10 @@
 import Base from "../../layouts/Base.astro";
 ---
 <Base title="Tables">
-  <div class="table-wrap">
-    <table class="table table--comfortable">
-      <thead><tr><th>Name</th><th>Role</th><th>Status</th></tr></thead>
-      <tbody>
-        <tr><td>Jane</td><td>Designer</td><td>Active</td></tr>
-        <tr><td>Mark</td><td>Dev</td><td>Invited</td></tr>
-      </tbody>
+  <div class="container">
+    <table class="table">
+      <thead><tr><th>Label</th><th>Value</th></tr></thead>
+      <tbody><tr><td>One</td><td>Alpha</td></tr><tr><td>Two</td><td>Beta</td></tr></tbody>
     </table>
   </div>
 </Base>

--- a/sites/docs/src/pages/components/tabs.astro
+++ b/sites/docs/src/pages/components/tabs.astro
@@ -2,12 +2,12 @@
 import Base from "../../layouts/Base.astro";
 ---
 <Base title="Tabs">
-  <div class="tabs">
-    <div class="tabs__list">
-      <button class="tabs__tab" aria-selected="true">One</button>
-      <button class="tabs__tab" aria-selected="false">Two</button>
+  <div class="container">
+    <div class="tabs" role="tablist" aria-label="Sample tabs">
+      <button role="tab" aria-controls="t1" aria-selected="true">Alpha</button>
+      <button role="tab" aria-controls="t2">Beta</button>
     </div>
-    <section class="tabs__panel">Panel 1</section>
-    <section class="tabs__panel" hidden>Panel 2</section>
+    <div id="t1" class="tabs__panel">Alpha content</div>
+    <div id="t2" class="tabs__panel" hidden>Beta content</div>
   </div>
 </Base>

--- a/sites/docs/src/pages/components/utilities.astro
+++ b/sites/docs/src/pages/components/utilities.astro
@@ -2,7 +2,11 @@
 import Base from "../../layouts/Base.astro";
 ---
 <Base title="Utilities">
-  <div class="u-p-4 card">Padding .u-p-4</div>
-  <div class="u-m-4 notice">Margin .u-m-4</div>
-  <div class="u-flex"><div class="card u-p-2">Flex 1</div><div class="card u-p-2">Flex 2</div></div>
+  <div class="container stack">
+    <div class="demo-card u-flex u-items-center u-gap-2">
+      <span>Flex row with gaps</span>
+      <button class="btn btn--ghost">Ghost</button>
+    </div>
+    <div class="demo-card u-p-4">Padding utility (.u-p-4)</div>
+  </div>
 </Base>

--- a/sites/docs/src/styles/docs.css
+++ b/sites/docs/src/styles/docs.css
@@ -1,0 +1,10 @@
+:root {
+  --page-max: 72rem;
+  --gap-1: .5rem; --gap-2: 1rem; --gap-3: 1.5rem; --gap-4: 2rem;
+}
+.container { max-width: var(--page-max); margin-inline: auto; padding: var(--gap-4) var(--gap-2); }
+.stack { display:flex; flex-direction:column; gap: var(--gap-2); }
+.stack--lg { gap: var(--gap-3); }
+.grid { display:grid; gap: var(--gap-2); grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); }
+.hr { height:1px; background: color-mix(in oklch, var(--sl-color-text), transparent 85%); margin: var(--gap-3) 0; }
+.demo-card { padding: var(--gap-2); border-radius: var(--sl-radius-lg); background: var(--sl-color-overlay); box-shadow: var(--sl-shadow-1); }


### PR DESCRIPTION
## Summary
- add docs.css for container and utility styling
- import docs.css in Base layout
- scaffold polished component demo pages (buttons, notices, cards, fields, tabs, stack, modal, tables, grid, utilities)

## Testing
- `npm run docs:build`
- `npm run docs:verify`


------
https://chatgpt.com/codex/tasks/task_e_68beca5f749883299d50283dd5f63249