### PR TITLE
docs: restore tabs/stack markup to match JS init hooks

### DIFF
--- a/sites/docs/src/pages/components/stack.astro
+++ b/sites/docs/src/pages/components/stack.astro
@@ -4,10 +4,14 @@ import Base from "../../layouts/Base.astro";
 <Base title="Stack (Accordion)">
   <div class="container">
     <div class="stack" data-accordion>
-      <button class="stack__header">Section A</button>
-      <div class="stack__panel">A content</div>
-      <button class="stack__header">Section B</button>
-      <div class="stack__panel">B content</div>
+      <div class="stack__item">
+        <button class="stack__header" aria-controls="sect-a" aria-expanded="true">Section A</button>
+        <div id="sect-a" class="stack__panel">A content</div>
+      </div>
+      <div class="stack__item">
+        <button class="stack__header" aria-controls="sect-b" aria-expanded="false">Section B</button>
+        <div id="sect-b" class="stack__panel" hidden>B content</div>
+      </div>
     </div>
   </div>
 </Base>

--- a/sites/docs/src/pages/components/tabs.astro
+++ b/sites/docs/src/pages/components/tabs.astro
@@ -3,11 +3,13 @@ import Base from "../../layouts/Base.astro";
 ---
 <Base title="Tabs">
   <div class="container">
-    <div class="tabs" role="tablist" aria-label="Sample tabs">
-      <button role="tab" aria-controls="t1" aria-selected="true">Alpha</button>
-      <button role="tab" aria-controls="t2">Beta</button>
+    <div class="tabs" data-tabs>
+      <div class="tabs__list" role="tablist" aria-label="Sample tabs">
+        <button class="tabs__tab" id="tab-a" role="tab" aria-controls="panel-a" aria-selected="true">Alpha</button>
+        <button class="tabs__tab" id="tab-b" role="tab" aria-controls="panel-b" aria-selected="false" tabindex="-1">Beta</button>
+      </div>
+      <div id="panel-a" class="tabs__panel" role="tabpanel" aria-labelledby="tab-a">Alpha content</div>
+      <div id="panel-b" class="tabs__panel" role="tabpanel" aria-labelledby="tab-b" hidden>Beta content</div>
     </div>
-    <div id="t1" class="tabs__panel">Alpha content</div>
-    <div id="t2" class="tabs__panel" hidden>Beta content</div>
   </div>
 </Base>


### PR DESCRIPTION
## Summary
- restore tabs markup with `.tabs__list`, `.tabs__tab`, and `.tabs__panel` hooks
- restore stack accordion `.stack__item` wrappers and header buttons

## Testing
- `npm run docs:build`
- `npm run docs:verify`


------
https://chatgpt.com/codex/tasks/task_e_68bed220931883299f16f32eec48ddb1