### PR TITLE
core(tokens): lighten secondary for contrast; propagate to components; rebuild

### DIFF
--- a/packages/components/src/button/_button.scss
+++ b/packages/components/src/button/_button.scss
@@ -4,3 +4,5 @@
 .btn--ghost{background:color-mix(in oklab,var(--color-primary),white 90%);color:var(--color-primary)}
 .btn--outline{background:transparent;color:var(--color-primary);border:1px solid var(--color-primary)}
 .btn--sm{padding:.5rem .75rem}.btn--lg{padding:.75rem 1.25rem}
+
+.btn.btn--secondary{background:var(--sl-color-secondary); color: var(--sl-color-text);}

--- a/packages/core/dist/index.css
+++ b/packages/core/dist/index.css
@@ -1,9 +1,70 @@
-:root{--font-sans:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:16px}
-h1{font-family:var(--font-sans);font-size:clamp(2.25rem,4vw,3rem)}
-h2{font-family:var(--font-sans);font-size:clamp(1.75rem,3vw,2.25rem)}
-h3{font-family:var(--font-sans);font-size:clamp(1.5rem,2.5vw,1.875rem)}
-:root{--brand-echo-light:#b8d2ed;--brand-slate-muted:#566590;--brand-indigogray:#42436c;--brand-teal-deep:#1c4566;--brand-slate-dark:#323460;--brand-navy-midnight:#03284f;--color-bg:#f7f8fa;--color-surface:#ffffff;--color-border:#e5e9f2;--color-text:#0f1220}
-@media (prefers-color-scheme: dark){:root{--color-bg:#0e121b;--color-surface:#121826;--color-border:#1f293b;--color-text:#e8edf7}}
-[data-theme="dark"]{--color-bg:#0e121b;--color-surface:#121826;--color-border:#1f293b;--color-text:#e8edf7}
-*,*::before,*::after{box-sizing:border-box}html{color-scheme:light dark}body{margin:0;background:var(--color-bg);color:var(--color-text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-h1,h2,h3{font-weight:700}p{line-height:1.6}
+:root {
+  --font-sans:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  font-size: 16px;
+}
+
+h1 {
+  font-family: var(--font-sans);
+  font-size: clamp(2.25rem, 4vw, 3rem);
+}
+
+h2 {
+  font-family: var(--font-sans);
+  font-size: clamp(1.75rem, 3vw, 2.25rem);
+}
+
+h3 {
+  font-family: var(--font-sans);
+  font-size: clamp(1.5rem, 2.5vw, 1.875rem);
+}
+
+:root {
+  --brand-echo-light:#b8d2ed;
+  --brand-slate-muted:#566590;
+  --brand-indigogray:#42436c;
+  --brand-teal-deep:#1c4566;
+  --brand-slate-dark:#323460;
+  --brand-navy-midnight:#03284f;
+  --color-bg:#f7f8fa;
+  --color-surface:#ffffff;
+  --color-border:#e5e9f2;
+  --color-text:#0f1220;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-bg:#0e121b;
+    --color-surface:#121826;
+    --color-border:#1f293b;
+    --color-text:#e8edf7;
+  }
+}
+[data-theme=dark] {
+  --color-bg:#0e121b;
+  --color-surface:#121826;
+  --color-border:#1f293b;
+  --color-text:#e8edf7;
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+}
+
+h1, h2, h3 {
+  font-weight: 700;
+}
+
+p {
+  line-height: 1.6;
+}

--- a/packages/core/dist/palette.css
+++ b/packages/core/dist/palette.css
@@ -1,1 +1,12 @@
-:root{--brand-echo-light:#b8d2ed;--brand-slate-muted:#566590;--brand-indigogray:#42436c;--brand-teal-deep:#1c4566;--brand-slate-dark:#323460;--brand-navy-midnight:#03284f;--color-bg:#f7f8fa;--color-surface:#ffffff;--color-border:#e5e9f2;--color-text:#0f1220}
+:root {
+  --brand-echo-light:#b8d2ed;
+  --brand-slate-muted:#566590;
+  --brand-indigogray:#42436c;
+  --brand-teal-deep:#1c4566;
+  --brand-slate-dark:#323460;
+  --brand-navy-midnight:#03284f;
+  --color-bg:#f7f8fa;
+  --color-surface:#ffffff;
+  --color-border:#e5e9f2;
+  --color-text:#0f1220;
+}

--- a/packages/core/src/tokens/_roles.scss
+++ b/packages/core/src/tokens/_roles.scss
@@ -1,0 +1,9 @@
+:root {
+  --sl-color-secondary: oklch(96% 0.02 250);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root, :root[data-theme="dark"] {
+  --sl-color-secondary: oklch(24% 0.02 250);
+  }
+}

--- a/sites/docs/src/styles/slate.css
+++ b/sites/docs/src/styles/slate.css
@@ -354,6 +354,11 @@ table.table {
   padding: 0.75rem 1.25rem;
 }
 
+.btn.btn--secondary {
+  background: var(--sl-color-secondary);
+  color: var(--sl-color-text);
+}
+
 /* components entry */
 
 .sr-only {


### PR DESCRIPTION
## Summary
- add secondary color role with light and dark tokens
- hook secondary button variant to new token
- rebuild core styles and docs

## Testing
- `npm run build`
- `npm run verify:dist`
- `npm run docs:build`
- `npm run docs:verify`


------
https://chatgpt.com/codex/tasks/task_e_68bed45924588329afb50f9cbce48280