### PR TITLE
core(tokens): forward roles; add --sl-color-text alias; fix secondary button text contrast

### DIFF
--- a/packages/components/src/button/_button.scss
+++ b/packages/components/src/button/_button.scss
@@ -5,4 +5,4 @@
 .btn--outline{background:transparent;color:var(--color-primary);border:1px solid var(--color-primary)}
 .btn--sm{padding:.5rem .75rem}.btn--lg{padding:.75rem 1.25rem}
 
-.btn.btn--secondary{background:var(--sl-color-secondary); color: var(--sl-color-text);}
+.btn.btn--secondary{background:var(--sl-color-secondary); color: var(--sl-color-text, var(--color-text));}

--- a/packages/core/dist/index.css
+++ b/packages/core/dist/index.css
@@ -31,6 +31,17 @@ h3 {
   --color-text:#0f1220;
 }
 
+:root {
+  --sl-color-text: var(--color-text);
+  --sl-color-secondary: oklch(96% 0.02 250);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root, :root[data-theme=dark] {
+    --sl-color-text: var(--color-text);
+    --sl-color-secondary: oklch(24% 0.02 250);
+  }
+}
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg:#0e121b;

--- a/packages/core/src/index.scss
+++ b/packages/core/src/index.scss
@@ -1,2 +1,3 @@
 @forward "typography/scale";
-@forward "tokens/palette";@forward "tokens/shade";@forward "base/reset";@forward "base/base";
+@forward "tokens/palette";
+@forward "tokens/roles";@forward "tokens/shade";@forward "base/reset";@forward "base/base";

--- a/packages/core/src/tokens/_roles.scss
+++ b/packages/core/src/tokens/_roles.scss
@@ -1,9 +1,11 @@
 :root {
+  --sl-color-text: var(--color-text);
   --sl-color-secondary: oklch(96% 0.02 250);
 }
 
 @media (prefers-color-scheme: dark) {
   :root, :root[data-theme="dark"] {
+  --sl-color-text: var(--color-text);
   --sl-color-secondary: oklch(24% 0.02 250);
   }
 }

--- a/sites/docs/src/styles/slate.css
+++ b/sites/docs/src/styles/slate.css
@@ -31,6 +31,17 @@ h3 {
   --color-text:#0f1220;
 }
 
+:root {
+  --sl-color-text: var(--color-text);
+  --sl-color-secondary: oklch(96% 0.02 250);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root, :root[data-theme=dark] {
+    --sl-color-text: var(--color-text);
+    --sl-color-secondary: oklch(24% 0.02 250);
+  }
+}
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg:#0e121b;
@@ -356,7 +367,7 @@ table.table {
 
 .btn.btn--secondary {
   background: var(--sl-color-secondary);
-  color: var(--sl-color-text);
+  color: var(--sl-color-text, var(--color-text));
 }
 
 /* components entry */


### PR DESCRIPTION
## Summary
- forward roles tokens from core
- add `--sl-color-text` alias to roles
- ensure secondary button text falls back to base text color

## Testing
- `npm run build`
- `npm run verify:dist`
- `npm run docs:build`
- `npm run docs:verify`


------
https://chatgpt.com/codex/tasks/task_e_68beda6ae63c83298ec71735b69b4f2f