### PR TITLE
test(ui): add Playwright UI suite for tabs, stack, modal, and button; serve built docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "docs:diagnose": "node scripts/docs-diagnose.mjs",
     "docs:selfcheck": "node scripts/docs-selfcheck.mjs",
     "docs:build": "npm --prefix sites/docs run prebuild && npm --prefix sites/docs run build",
-    "docs:verify": "node scripts/docs-verify.mjs"
+    "docs:verify": "node scripts/docs-verify.mjs",
+    "test:ui:serve": "PORT=4173 node scripts/serve-docs.mjs",
+    "test:ui": "npm run docs:build && (npm run -s test:ui:serve & SERVER_PID=$!; BASE_URL=http://localhost:4173/Slate npx playwright test tests/ui --project=chromium --reporter=line; EXIT=$?; kill $SERVER_PID; exit $EXIT)"
   },
   "devDependencies": {
     "size-limit": "^11.0.0"

--- a/scripts/serve-docs.mjs
+++ b/scripts/serve-docs.mjs
@@ -1,0 +1,22 @@
+import http from 'node:http';
+import { existsSync, createReadStream, statSync } from 'node:fs';
+import { resolve, extname } from 'node:path';
+
+const root = resolve('sites/docs/dist');
+const port = process.env.PORT || 4173;
+const base = '/Slate';
+
+const types = { '.html':'text/html','.css':'text/css','.js':'text/javascript','.mjs':'text/javascript','.json':'application/json','.svg':'image/svg+xml','.png':'image/png','.jpg':'image/jpeg','.ico':'image/x-icon','':'' };
+
+const server = http.createServer((req,res)=>{
+  let url = req.url || '/';
+  if (url === '/') url = base + '/';
+  if (url.startsWith(base)) url = url.slice(base.length) || '/';
+  let file = resolve(root + url);
+  if (!extname(file)) file = file.endsWith('/') ? file+'index.html' : file+'/index.html';
+  if (!existsSync(file)) { res.statusCode=404; res.end('Not found'); return; }
+  res.setHeader('Content-Type', types[extname(file)] || 'text/plain');
+  res.setHeader('Cache-Control', 'no-store');
+  createReadStream(file).pipe(res);
+});
+server.listen(port, ()=>console.log(`[serve-docs] http://localhost:${port}${base}`));

--- a/tests/ui/button.spec.ts
+++ b/tests/ui/button.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+const BASE = process.env.BASE_URL || "http://localhost:4173/Slate";
+test("Button: secondary variant renders with background", async ({ page }) => {
+  await page.goto(`${BASE}/components/button/`);
+  const secondary = page.locator(".btn.btn--secondary").first();
+  const bg = await secondary.evaluate(el => getComputedStyle(el).backgroundColor);
+  expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+});

--- a/tests/ui/modal.spec.ts
+++ b/tests/ui/modal.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+const BASE = process.env.BASE_URL || "http://localhost:4173/Slate";
+test("Modal: opens and closes", async ({ page }) => {
+  await page.goto(`${BASE}/components/modal/`);
+  await page.getByRole("button", { name: "Open modal" }).click();
+  const dialog = page.locator(".modal[role='dialog']");
+  await expect(dialog).toBeVisible();
+  // close
+  await page.getByRole("button", { name: "Close" }).click();
+  await expect(dialog).toBeHidden();
+});

--- a/tests/ui/stack.spec.ts
+++ b/tests/ui/stack.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+const BASE = process.env.BASE_URL || "http://localhost:4173/Slate";
+test("Stack: toggles sections via header buttons", async ({ page }) => {
+  await page.goto(`${BASE}/components/stack/`);
+  const items = page.locator(".stack__item");
+  await expect(items).toHaveCount(2);
+  const b = items.nth(1).locator(".stack__header");
+  const panel = items.nth(1).locator(".stack__panel");
+  await expect(panel).toBeHidden();
+  await b.click();
+  await expect(b).toHaveAttribute("aria-expanded","true");
+  await expect(panel).toBeVisible();
+});

--- a/tests/ui/tabs.spec.ts
+++ b/tests/ui/tabs.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+const BASE = process.env.BASE_URL || "http://localhost:4173/Slate";
+test("Tabs: click switches panels and manages aria", async ({ page }) => {
+  await page.goto(`${BASE}/components/tabs/`);
+  const tabs = page.locator(".tabs__tab");
+  const panels = page.locator(".tabs__panel");
+  await expect(tabs).toHaveCount(2);
+  await expect(panels.nth(0)).toBeVisible();
+  await expect(panels.nth(1)).toBeHidden();
+  await tabs.nth(1).click();
+  await expect(tabs.nth(1)).toHaveAttribute("aria-selected","true");
+  await expect(panels.nth(1)).toBeVisible();
+  await expect(panels.nth(0)).toBeHidden();
+});


### PR DESCRIPTION
## Summary
- add static server to serve built docs for tests
- create Playwright UI tests for tabs, stack, modal, and button components
- wire npm scripts to build docs and run UI suite

## Testing
- `npm run test:ui` *(fails: 403 Forbidden fetching playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68beef2ea320832981040850860ece62